### PR TITLE
Trim "\r" in sbt.version line of build.properties

### DIFF
--- a/sbt
+++ b/sbt
@@ -19,7 +19,7 @@ vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
 # spaces are possible, e.g. sbt.version = 0.13.0
 build_props_sbt () {
   [[ -r "$buildProps" ]] && \
-    grep '^sbt\.version' "$buildProps" | tr '=' ' ' | awk '{ print $2; }'
+    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
 }
 
 update_build_props_sbt () {

--- a/test/download.bats
+++ b/test/download.bats
@@ -26,9 +26,9 @@ launcher_url () {
   esac
 }
 
-echo_prop_and_fetch ()  { echo_to_properties "$1" && shift && fetch_launcher "$@"; }
-write_prop_and_fetch () { write_version_to_properties "$1" && fetch_launcher "$@"; }
-no_props_and_fetch ()   { assert_no_properties && fetch_launcher "$@"; }
+write_to_properties_and_fetch ()         { write_to_properties "$1" && shift && fetch_launcher "$@"; }
+write_version_to_properties_and_fetch () { write_version_to_properties "$1" && fetch_launcher "$@"; }
+no_properties_and_fetch ()               { assert_no_properties && fetch_launcher "$@"; }
 
 fetch_launcher () {
   local version="$1" && shift
@@ -43,16 +43,16 @@ EOS
   unstub curl
 }
 
-@test "downloads sbt 0.7.x"  { write_prop_and_fetch "$sbt_07"; }
-@test "downloads sbt 0.10.x" { write_prop_and_fetch "$sbt_10"; }
-@test "downloads sbt 0.11.x" { write_prop_and_fetch "$sbt_11"; }
-@test "downloads sbt 0.12.x" { write_prop_and_fetch "$sbt_12"; }
-@test "downloads sbt 0.13.x" { write_prop_and_fetch "$sbt_13"; }
+@test "downloads sbt 0.7.x"  { write_version_to_properties_and_fetch "$sbt_07"; }
+@test "downloads sbt 0.10.x" { write_version_to_properties_and_fetch "$sbt_10"; }
+@test "downloads sbt 0.11.x" { write_version_to_properties_and_fetch "$sbt_11"; }
+@test "downloads sbt 0.12.x" { write_version_to_properties_and_fetch "$sbt_12"; }
+@test "downloads sbt 0.13.x" { write_version_to_properties_and_fetch "$sbt_13"; }
 
-@test "downloads release version if build.properties is missing"    { no_props_and_fetch "$sbt_release"; }
-@test "downloads specified version when -sbt-version was given"     { no_props_and_fetch 0.12.2 -sbt-version 0.12.2; }
-@test "downloads released version when -sbt-force-latest was given" { no_props_and_fetch "$sbt_release" -sbt-force-latest; }
-@test "downloads unreleased version when -sbt-dev was given"        { no_props_and_fetch "$sbt_dev" -sbt-dev; }
+@test "downloads release version if build.properties is missing"    { no_properties_and_fetch "$sbt_release"; }
+@test "downloads specified version when -sbt-version was given"     { no_properties_and_fetch 0.12.2 -sbt-version 0.12.2; }
+@test "downloads released version when -sbt-force-latest was given" { no_properties_and_fetch "$sbt_release" -sbt-force-latest; }
+@test "downloads unreleased version when -sbt-dev was given"        { no_properties_and_fetch "$sbt_dev" -sbt-dev; }
 
 @test "downloads specified version when -sbt-version was given, even if there is build.properties" {
   write_version_to_properties $sbt_12
@@ -94,15 +94,15 @@ EOS
 }
 
 @test "allows surrounding white spaces around '=' in build.properties" {
-  echo_prop_and_fetch "sbt.version = 0.12.1" "0.12.1"
+  write_to_properties_and_fetch "sbt.version = 0.12.1" "0.12.1"
 }
 
 @test "supports windows line endings (crlf) in build.properties" {
-  echo_prop_and_fetch "sbt.version=0.22.0-M1\r" "0.22.0-M1"
+  write_to_properties_and_fetch "sbt.version=0.22.0-M1\r\n" "0.22.0-M1"
 }
 
 @test "supports unix line endings (lf) in build.properties" {
-  echo_prop_and_fetch "sbt.version=0.13.7\n" "0.13.7"
+  write_to_properties_and_fetch "sbt.version=0.13.7\n" "0.13.7"
 }
 
 @test "skips to download sbt-launch.jar if a file was given via -sbt-jar" {
@@ -114,7 +114,7 @@ EOS
 }
 
 @test "uses special launcher directory if -sbt-launch-dir was given" {
-  echo_to_properties "stub.version=$sbt_13"
+  write_to_properties "stub.version=$sbt_13"
   stub_curl
   run sbt -sbt-launch-dir "${sbt_project}/xsbt"
   assert_success
@@ -127,7 +127,7 @@ EOS
 }
 
 @test "uses special launcher repository if -sbt-launch-repo was given" {
-  echo_to_properties "stub.version=$sbt_13"
+  write_to_properties "stub.version=$sbt_13"
   stub_curl
   run sbt -sbt-launch-repo "http://127.0.0.1:8080/ivy-releases"
   assert_success

--- a/test/download.bats
+++ b/test/download.bats
@@ -97,11 +97,11 @@ EOS
   echo_prop_and_fetch "sbt.version = 0.12.1" "0.12.1"
 }
 
-@test "support windows line endings (crlf) in build.properties" {
+@test "supports windows line endings (crlf) in build.properties" {
   echo_prop_and_fetch "sbt.version=0.22.0-M1\r" "0.22.0-M1"
 }
 
-@test "support unix line endings (lf) in build.properties" {
+@test "supports unix line endings (lf) in build.properties" {
   echo_prop_and_fetch "sbt.version=0.13.7\n" "0.13.7"
 }
 

--- a/test/download.bats
+++ b/test/download.bats
@@ -97,6 +97,14 @@ EOS
   echo_prop_and_fetch "sbt.version = 0.12.1" "0.12.1"
 }
 
+@test "support windows line endings (crlf) in build.properties" {
+  echo_prop_and_fetch "sbt.version=0.22.0-M1\r" "0.22.0-M1"
+}
+
+@test "support unix line endings (lf) in build.properties" {
+  echo_prop_and_fetch "sbt.version=0.13.7\n" "0.13.7"
+}
+
 @test "skips to download sbt-launch.jar if a file was given via -sbt-jar" {
   touch sbt-launch.jar
   run sbt -sbt-jar sbt-launch.jar

--- a/test/download.bats
+++ b/test/download.bats
@@ -105,6 +105,10 @@ EOS
   write_to_properties_and_fetch "sbt.version=0.13.7\n" "0.13.7"
 }
 
+@test "skips any irrelevant lines in build.properties" {
+  write_to_properties_and_fetch "# hand written:\n\nsbt.version=0.13.7\nsbt.something = else\n" "0.13.7"
+}
+
 @test "skips to download sbt-launch.jar if a file was given via -sbt-jar" {
   touch sbt-launch.jar
   run sbt -sbt-jar sbt-launch.jar

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -16,7 +16,7 @@ export sbt_release="$sbt_13"
 export sbt_dev="0.13.8-M1"
 
 write_version_to_properties () { echo_to_properties "sbt.version=$1";  }
-echo_to_properties ()          { echo "$@" > "$test_build_properties"; }
+echo_to_properties ()          { echo -ne "$@" > "$test_build_properties"; }
 
 sbt_version_from_test_filename () {
   case "$BATS_TEST_FILENAME" in

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -15,8 +15,8 @@ export sbt_13="0.13.7"
 export sbt_release="$sbt_13"
 export sbt_dev="0.13.8-M1"
 
-write_version_to_properties () { echo_to_properties "sbt.version=$1";  }
-echo_to_properties ()          { echo -ne "$@" > "$test_build_properties"; }
+write_version_to_properties () { write_to_properties "sbt.version=$1";  }
+write_to_properties ()         { printf "$@" > "$test_build_properties"; }
 
 sbt_version_from_test_filename () {
   case "$BATS_TEST_FILENAME" in


### PR DESCRIPTION
@paulp this is a proposition to resolve #93 and restore a behaviour that was previously introduced by #44. 

Note that this "feature" is now covered by two unit tests for Windows format (CRLF) and Unix format (LF), but not for Mac-OS9 (CR).

//cc @MikeHoffert @szeiger