### PR TITLE
add openjdk 8 version detection

### DIFF
--- a/sbt
+++ b/sbt
@@ -186,7 +186,7 @@ declare sbt_launch_dir="$HOME/.sbt/launchers"
 [[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
 
 java_version () {
-  local version=$("$java_cmd" -version 2>&1 | grep -e 'java version' | awk '{ print $3 }' | tr -d \")
+  local version=$("$java_cmd" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d \")
   vlog "Detected Java version: $version"
   echo "${version:2:1}"
 }


### PR DESCRIPTION
OpenJDK 8 identifies itself as "openjdk" rather than "java" in the
output of `java -version`. the regular expression by grep used for java
version detection has been modified to handle both forms. the modified
form only uses grep arguments defined within the POSIX specification.
this modified version has been tested against the following operating
systems: Debian 8, Fedora 21, CentOS 7, Ubuntu 14.04, Ubuntu 14.10 and
Mac OS X 10.10 with a variety of JVMs. For completeness the
`java -version` output from a number of these operating systems has been
provided below:

Debian 8:

    $ /usr/lib/jvm/java-1.6.0-openjdk-amd64/bin/java -version
    java version "1.6.0_35"
    OpenJDK Runtime Environment (IcedTea6 1.13.7) (6b35-1.13.7-1)
    OpenJDK 64-Bit Server VM (build 23.25-b01, mixed mode)
    $ /usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java -version
    java version "1.7.0_75"
    OpenJDK Runtime Environment (IcedTea 2.5.4) (7u75-2.5.4-2)
    OpenJDK 64-Bit Server VM (build 24.75-b04, mixed mode)
    $ /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -version
    openjdk version "1.8.0_45-internal"
    OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
    OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)

Fedora 21: (java-1.8.0-openjdk-headless)

    $ java -version
    openjdk version "1.8.0_40"
    OpenJDK Runtime Environment (build 1.8.0_40-b25)
    OpenJDK 64-Bit Server VM (build 25.40-b25, mixed mode)

CentOS 7: (java-1.8.0-openjdk-headless)

    $ java -version
    openjdk version "1.8.0_45"
    OpenJDK Runtime Environment (build 1.8.0_45-b13)
    OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)

Ubuntu 14.10: (openjdk-8-jre-headless)

    $ java -version
    openjdk version "1.8.0_40-internal"
    OpenJDK Runtime Environment (build 1.8.0_40-internal-b09)
    OpenJDK 64-Bit Server VM (build 25.40-b13, mixed mode)

Ubuntu 14.04: (oracle-java)

    $ /usr/lib/jvm/java-6-oracle/jre/bin/java -version
    java version "1.6.0_45"
    Java(TM) SE Runtime Environment (build 1.6.0_45-b06)
    Java HotSpot(TM) 64-Bit Server VM (build 20.45-b01, mixed mode)
    $ /usr/lib/jvm/java-7-oracle/jre/bin/java -version
    java version "1.7.0_76"
    Java(TM) SE Runtime Environment (build 1.7.0_76-b13)
    Java HotSpot(TM) 64-Bit Server VM (build 24.76-b04, mixed mode)
    $ /usr/lib/jvm/java-8-oracle/jre/bin/java -version
    java version "1.8.0_40"
    Java(TM) SE Runtime Environment (build 1.8.0_40-b25)
    Java HotSpot(TM) 64-Bit Server VM (build 25.40-b25, mixed mode)

Mac OS X 10.10:

    $ java -version
    java version "1.7.0_71"
    Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
    Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)