### PR TITLE
Start an SBT shell when no command is specified

### DIFF
--- a/sbt
+++ b/sbt
@@ -499,6 +499,9 @@ fi
 [[ -n "$trace_level" ]] && setTraceLevel
 
 main () {
+  if test 0 -eq ${#sbt_commands} ; then
+    sbt_commands=( "shell" )
+  fi
   execRunner "$java_cmd" \
     "${extra_jvm_opts[@]}" \
     "${java_args[@]}" \


### PR DESCRIPTION
When "sbt" is executed without any command, it doesn't start an sbt shell, but it loads everything (which can take a while) and then promptly exits.