### PR TITLE
Update to v0.13.9 & update to new ivy repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ runner with the -x option.
   # sbt version (default: sbt.version from project/build.properties if present, otherwise 0.13.8)
   -sbt-force-latest         force the use of the latest release of sbt: 0.13.8
   -sbt-version  <version>   use the specified version of sbt (default: 0.13.8)
-  -sbt-dev                  use the latest pre-release version of sbt: 0.13.8
+  -sbt-dev                  use the latest pre-release version of sbt: 0.13.9-M1
   -sbt-jar      <path>      use the specified jar as the sbt launcher
   -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
   -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: http://repo.typesafe.com/typesafe/ivy-releases)

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ runner with the -x option.
   # sbt version (default: sbt.version from project/build.properties if present, otherwise 0.13.8)
   -sbt-force-latest         force the use of the latest release of sbt: 0.13.8
   -sbt-version  <version>   use the specified version of sbt (default: 0.13.8)
-  -sbt-dev                  use the latest pre-release version of sbt: 0.13.8-M6
+  -sbt-dev                  use the latest pre-release version of sbt: 0.13.8
   -sbt-jar      <path>      use the specified jar as the sbt launcher
   -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
-  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: http://typesafe.artifactoryonline.com/typesafe/ivy-releases)
+  -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: http://repo.typesafe.com/typesafe/ivy-releases)
 
   # scala version (default: as chosen by sbt)
   -28                       use 2.8.2

--- a/sbt
+++ b/sbt
@@ -115,7 +115,7 @@ declare -r script_name="${script_path##*/}"
 declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://typesafe.artifactoryonline.com/typesafe/ivy-releases"
+declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args

--- a/sbt
+++ b/sbt
@@ -244,7 +244,7 @@ download_url () {
 
   mkdir -p "${jar%/*}" && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/sbt
+++ b/sbt
@@ -5,7 +5,7 @@
 
 # todo - make this dynamic
 declare -r sbt_release_version="0.13.8"
-declare -r sbt_unreleased_version="0.13.8"
+declare -r sbt_unreleased_version="0.13.9-M1"
 declare -r buildProps="project/build.properties"
 
 declare sbt_jar sbt_dir sbt_create sbt_version

--- a/test/download.bats
+++ b/test/download.bats
@@ -21,8 +21,8 @@ stub_wget() { stub wget "$wget_opts"; }
 launcher_url () {
   case "$1" in
     0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-$1.jar" ;;
-   0.10.*) echo "http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
-        *) echo "http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+   0.10.*) echo "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
+        *) echo "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
   esac
 }
 
@@ -61,7 +61,7 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_13:
-  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
+  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_13/sbt-launch.jar
 EOS
   unstub curl
@@ -74,7 +74,7 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_release:
-  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_release/sbt-launch.jar
+  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_release/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_release/sbt-launch.jar
 EOS
   unstub curl
@@ -87,7 +87,7 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_dev:
-  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_dev/sbt-launch.jar
+  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_dev/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_dev/sbt-launch.jar
 EOS
   unstub curl
@@ -124,7 +124,7 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_13:
-  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
+  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
     To  ${sbt_project}/xsbt/$sbt_13/sbt-launch.jar
 EOS
   unstub curl

--- a/test/download.bats
+++ b/test/download.bats
@@ -12,7 +12,7 @@ teardown() {
   rm -fr "$TEST_ROOT"/* "$TEST_ROOT"/.sbt
 }
 
-curl_opts='--fail --silent http://* --output * : mkdir -p "$(dirname "$5")" && touch "$5"'
+curl_opts='--fail --silent --location http://* --output * : mkdir -p "$(dirname "$6")" && touch "$6"'
 wget_opts='--quiet -O * http://* : mkdir -p "$(dirname "$3")" && touch "$3"'
 
 stub_curl() { stub curl "$curl_opts"; }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,7 +13,7 @@ export sbt_11="0.11.3"
 export sbt_12="0.12.4"
 export sbt_13="0.13.8"
 export sbt_release="$sbt_13"
-export sbt_dev="0.13.8"
+export sbt_dev="0.13.9-M1"
 
 write_version_to_properties () { write_to_properties "sbt.version=$1";  }
 write_to_properties ()         { printf "$@" > "$test_build_properties"; }


### PR DESCRIPTION
Looking in https://repo.typesafe.com/typesafe/ivy-releases it seems the current
version-matching rules in mark_url would continue to work with this new
repository, and it includes 0.13.9-M1, which is missing in artifactoryonline.