### PR TITLE
Replace http with https for typesafe repo URI

### DIFF
--- a/sbt
+++ b/sbt
@@ -115,7 +115,7 @@ declare -r script_name="${script_path##*/}"
 declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare sbt_launch_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args


### PR DESCRIPTION
sbt fails to auto-download launchers since http is decommissioned.