### PR TITLE
eval lines for the read configuration files

### DIFF
--- a/sbt
+++ b/sbt
@@ -396,7 +396,7 @@ process_args "$@"
 # skip #-styled comments and blank lines
 readConfigFile() {
   while read line; do
-    [[ $line =~ ^# ]] || [[ -z $line ]] || echo "$line"
+    [[ $line =~ ^# ]] || [[ -z $line ]] || eval "echo $line"
   done < "$1"
 }
 

--- a/test/config-file.bats
+++ b/test/config-file.bats
@@ -7,7 +7,7 @@ configFile () { cat <<EOM
 # Comment 2, followed by blank line
 
 -Xmx1g
--Dsome.prop="pass a # in a string"
+-Dsome.prop='"pass a # in a string"'
 
 -Xss4m
 # Comment 4


### PR DESCRIPTION
It's just nice to use parameter expansion in configuration files like .sbtopts,
so they can be checked into source control and still generalize to different
environments.

The motivating example was the following .sbtopts file:

    -Dsbt.boot.credentials=$HOME/.sbt/credentials
    -Dsbt.override.build.repos=true

Before, this wouldn't work because $HOME wouldn't be expanded.  With this
commit, it now expands.