### PR TITLE
Correct exit status when output filtering enabled

### DIFF
--- a/sbt
+++ b/sbt
@@ -3,6 +3,8 @@
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@improving.org>
 
+set -o pipefail
+
 # todo - make this dynamic
 declare -r sbt_release_version="0.13.9"
 declare -r sbt_unreleased_version="0.13.9"


### PR DESCRIPTION
Currently, if `~/.sbtignore` exists, sbt-extras would return 0 even if the `sbt` command failed

e.g.,
```
$ rm ~/.sbtignore
$ ./sbt -sbt-create asdfg; echo "exit status was $?"
[info] Set current project to sbt-extras (in build file:/private/tmp/sbt-extras/)
[error] Not a valid command: asdfg (similar: last)
[error] Not a valid project ID: asdfg
[error] Expected ':' (if selecting a configuration)
[error] Not a valid key: asdfg (similar: tags)
[error] asdfg
[error]      ^
exit status was 1

$ touch ~/.sbtignore
$ ./sbt -sbt-create asdfg; echo "exit status was $?"
Starting sbt with output filtering enabled.
[info] Set current project to sbt-extras (in build file:/private/tmp/sbt-extras/)
[error] Not a valid command: asdfg (similar: last)
[error] Not a valid project ID: asdfg
[error] Expected ':' (if selecting a configuration)
[error] Not a valid key: asdfg (similar: tags)
[error] asdfg
[error]      ^
exit status was 0
```

(in a more realistic scenario, I'm running `sbt test`, where the tests fail but the command returns 0 because `~/.sbtignore` exists)