### PR TITLE
Add Travis-CI support for OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,29 @@
 sudo: false
+
+language: java
+
+before_script: 
+    - ./test/travis.deps.bash
+
 script: ./bin/run-tests --tap ./test
-language: c
+
+
+matrix:
+  include:
+
+    - os: linux
+      jdk: oraclejdk8
+    - os: linux
+      jdk: oraclejdk7
+    - os: linux
+      jdk: openjdk7
+
+# Due to travis-ci/travis-ci/issues/2317, we can't use `jdk:` directly 
+    - os: osx
+      env: JDK_VERSION=oraclejdk8
+    - os: osx
+      env: JDK_VERSION=oraclejdk7
+
 notifications:
   email:
     on_success: never
-
-jdk:
-  - openjdk7
-  - oraclejdk8

--- a/test/travis.deps.bash
+++ b/test/travis.deps.bash
@@ -17,13 +17,6 @@ if ! env | grep -qE '^(?:TRAVIS|CI)='; then
     echo "WARNING: This script is meant to be run by Travis-CI services."
 fi
 
-if [ -z "${JDK_VERSION}" ]; then
-    echo "Error: JDK_VERSION environment variable not found"
-    echo "    Valid options: oraclejdk7 oraclejdk8 oraclejdk9 "
-    echo "                   openjdk7 openjdk8"
-    exit 1
-fi
-
 install_os_deps() {
     # Install all of the OS specific OS dependencies
     local jdk_version_level=${JDK_VERSION:(-1)}
@@ -32,6 +25,13 @@ install_os_deps() {
 
     case ${os_name} in
         osx)
+            if [ -z "${JDK_VERSION}" ]; then
+                echo "Error: On OSX, JDK_VERSION environment must be specified."
+                echo "    Valid options: oraclejdk7 oraclejdk8 oraclejdk9 "
+                echo "                   openjdk7 openjdk8"
+                exit 1
+            fi
+            
             if [[ ${JDK_VERSION} == openjdk* ]] ; then
                 echo "OpenJDK is not supported on osx, defaulting to oraclejdk${jdk_version_level}"
                 export JDK_VERSION=oraclejdk${jdk_version_level}

--- a/test/travis.deps.bash
+++ b/test/travis.deps.bash
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# This script installs and configures the dependencies for the sbt-extras
+# Author: Kevin Brightwell (Github: Nava2)
+
+declare OS_NAME
+
+case `uname` in 
+    Darwin)     OS_NAME="osx"    ;;
+    Linux)      OS_NAME="linux"  ;;
+esac
+
+if env | grep -qE '^(?:TRAVIS|CI)='; then
+#    We're on Travis, intialize variables:
+    echo "Detected CI Build -> CI=${CI}"
+
+else
+#   We're building locally
+    echo "This script is meant to be run by Travis-CI services."
+
+    # exit 1
+fi
+
+echo "Building on: ${OS_NAME}"
+
+install_os_deps() {
+    # Install all of the OS specific OS dependencies
+    local JDK_VERSION_LEVEL=${JDK_VERSION:(-1)}
+
+    echo "Attempting to use Java: ${JDK_VERSION}"
+
+    case ${OS_NAME} in
+        osx)
+            if [[ ${JDK_VERSION} == openjdk* ]] ; then
+                echo "OpenJDK is not supported on OSX, defaulting to oraclejdk${JDK_VERSION_LEVEL}"
+                export JDK_VERSION=oraclejdk${JDK_VERSION_LEVEL}
+            fi
+            
+            # Install the correct version of Java:
+
+            case ${JDK_VERSION_LEVEL} in
+                8)
+                    CASK_PKG=caskroom/cask;
+                    JAVA_PKG="java"
+                    ;;
+                7|9)
+                    CASK_PKG=caskroom/versions;
+                    JAVA_PKG="java${JDK_VERSION_LEVEL}";
+                    #echo "Invalid Java Version, ${JDK_VERSION}"
+                    # exit 1
+                    ;;
+            esac
+
+            echo "Installing ${JDK_VERSION} from: ${CASK_PKG}:${JAVA_PKG}"
+
+            brew tap ${CASK_PKG}
+
+            echo "brew update ..." ; brew update > /dev/null #; brew doctor; brew update
+
+            brew cask install ${JAVA_PKG}
+        ;;
+
+        linux)
+            
+        ;;
+    esac
+
+    java -version
+}
+
+install_os_deps


### PR DESCRIPTION
* Add `test/travis.deps.bash` to install dependencies (e.g. Java) on OSX
* Now runs `bats` against OSX

Caveats:

* OpenJDK is ignored on OSX

Closes #126.