### PR TITLE
Setup Travis for OS X, Gitter & speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 sudo: false
-script: ./bin/run-tests --tap ./test
 language: c
+os:
+- linux
+- osx
+
+git:
+  depth: 3
+
+script: ./bin/run-tests --tap ./test
+
 notifications:
   email:
     on_success: never
-
-jdk:
-  - openjdk7
-  - oraclejdk8
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/901694477147612308dd
+    on_success: change
+    on_failure: always
+    on_start: never

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -10,5 +10,5 @@ bats=""
 
 [[ $# -gt 0   ]] || set -- ./test
 [[ -x "$bats" ]] || bats="./bats/bin/bats"
-[[ -x "$bats" ]] || git clone https://github.com/sstephenson/bats.git bats
+[[ -x "$bats" ]] || git clone --depth=1 https://github.com/sstephenson/bats.git bats
 [[ -x "$bats" ]] && "$bats" "$@"


### PR DESCRIPTION
Add OS X as a target OS, giving us better coverage of BSD-variants of the
userland tools (grep, sed, etc). Note that this increases the build from ~40s to
~1m30.

Kill JDKs as they weren't needed and were misleading. Note that both Linux and
OS X docker containers have Java 7 installed, but the tests never use Java.

Configure Gitter webhook for Travis

Also attempt to speed up the build by using git depth. Doesn't seem to have much
of an effect, but it can't hurt.

Closes #126
Superseeds #127