### PR TITLE
Drop OS X support for Travis..

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: c
-os:
-- linux
-- osx
 
 git:
   depth: 3
@@ -13,8 +10,4 @@ notifications:
   email:
     on_success: never
   webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/45b53a6d489dbced3f7e
-    on_success: change
-    on_failure: always
-    on_start: never
+    urls: https://webhooks.gitter.im/e/45b53a6d489dbced3f7e


### PR DESCRIPTION
This reverts the principle change in #129.

Continuing from where that commit message left off, the reason that the tests
never use Java is that's how bats works: nothing on the PATH is used.

Therefore there's no strong reason to test on both Linux and OS X as it's only
testing potential variations of whatever version of bash is running.

So dropping OS X support reduces the travis setup and recovers some speed in the
builds (hopefully back to ~40s from ~1m30).

Note OS X support might come back with #132.