### PR TITLE
Incorrect parse of multiword lines in sbtopts file.

### DIFF
--- a/sbt
+++ b/sbt
@@ -429,7 +429,7 @@ readConfigFile() {
 # can supply args to this runner
 if [[ -r "$sbt_opts_file" ]]; then
   vlog "Using sbt options defined in file $sbt_opts_file"
-  while read opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
+  while read opt; do for an_opt in $opt; do extra_sbt_opts+=("$an_opt"); done ; done < <(readConfigFile "$sbt_opts_file")
 elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
   vlog "Using sbt options defined in variable \$SBT_OPTS"
   extra_sbt_opts=( $SBT_OPTS )


### PR DESCRIPTION
Parsing an sbtopts file containing something like:

    -ivy /foo/.ivy2

causes the following to be generated on the command line

    execRunner /usr/lib/jvm/java-7-openjdk-amd64/bin/java -XX:MaxPermSize=384m -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -jar /foo/sbt/bin/sbt-launch.jar warn 'set javaHome in ThisBuild := scala.Some(file("/usr/lib/jvm/java-7-openjdk-amd64"))' info clean '-ivy /foo/.ivy

which in turn provokes

    [warn] The `-` command is deprecated in favor of `onFailure` and will be removed in 0.14.0

This is due to the way the contents of individual lines are added to extra_sbt_opts.

A local, simple fix is to add another looping construct to add each word individually instead of each line.