### PR TITLE
Add the possibility to run scala scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ runner with the -x option.
   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
   -batch             Disable interactive mode
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
+  -script <file>     Run the specified file as a scala script
 
   # sbt version (default: sbt.version from project/build.properties if present, otherwise 0.13.11)
   -sbt-force-latest         force the use of the latest release of sbt: 0.13.11

--- a/test/options.bats
+++ b/test/options.bats
@@ -2,13 +2,14 @@
 
 load test_helper
 
-@test "-ivy       => -Dsbt.ivy.home"       { sbt_expecting "-Dsbt.ivy.home=$sbt_project/ivy" -ivy "$sbt_project/ivy";                               }
-@test "-no-colors => -Dsbt.log.noformat"   { sbt_expecting "-Dsbt.log.noformat=true" -no-colors;                                                    }
-@test "-sbt-boot  => -Dsbt.boot.directory" { sbt_expecting "-Dsbt.boot.directory=$sbt_project/sbt.boot" -sbt-boot "$sbt_project/sbt.boot";          }
-@test "-debug-inc => -Dxsbt.inc.debug"     { sbt_expecting "-Dxsbt.inc.debug=true" -debug-inc;                                                      }
-@test "-offline   => offline setting"      { sbt_expecting "set offline := true" -offline;                                                          }
-@test "-Sopt      => scalac -opt"          { sbt_expecting 'set scalacOptions in ThisBuild += "-P:continuations:enable"' -S-P:continuations:enable; }
-@test "-prompt    => shellPrompt"          { sbt_expecting "set shellPrompt in ThisBuild" -prompt 'bippy> ';                                        }
+@test "-ivy       => -Dsbt.ivy.home"                  { sbt_expecting "-Dsbt.ivy.home=$sbt_project/ivy" -ivy "$sbt_project/ivy";                               }
+@test "-no-colors => -Dsbt.log.noformat"              { sbt_expecting "-Dsbt.log.noformat=true" -no-colors;                                                    }
+@test "-sbt-boot  => -Dsbt.boot.directory"            { sbt_expecting "-Dsbt.boot.directory=$sbt_project/sbt.boot" -sbt-boot "$sbt_project/sbt.boot";          }
+@test "-debug-inc => -Dxsbt.inc.debug"                { sbt_expecting "-Dxsbt.inc.debug=true" -debug-inc;                                                      }
+@test "-offline   => offline setting"                 { sbt_expecting "set offline := true" -offline;                                                          }
+@test "-Sopt      => scalac -opt"                     { sbt_expecting 'set scalacOptions in ThisBuild += "-P:continuations:enable"' -S-P:continuations:enable; }
+@test "-prompt    => shellPrompt"                     { sbt_expecting "set shellPrompt in ThisBuild" -prompt 'bippy> ';                                        }
+@test "-script    => -Dsbt.main.class=sbt.ScriptMain" { sbt_expecting "-Dsbt.main.class=sbt.ScriptMain" -script params;                                        }
 
 @test "-jvm-debug => -Xdebug, -Xrunjdwp:transport" {
   sbt_expecting "-Xdebug" -jvm-debug 8000


### PR DESCRIPTION
This is a very naive implementation in order to support running scala scripts, even in folders that do not contain sbt projects. Saving the following snippet 
```scala
/***

libraryDependencies += "com.github.lalyos" % "jfiglet" % "0.0.7"

*/

import com.github.lalyos.jfiglet.FigletFont;
val msg = if (args.size > 0) args.mkString(" ") else ""
val asciiArt = FigletFont.convertOneLine(s"hello $msg!");
System.out.println(asciiArt);
```
and running `sbt -script snippet.scala sbt extra` yields

```
[info] Loading global plugins from /home/user/.sbt/0.13/plugins
[info] Set current project to cc88a3ff57276e4d8968 (in build file:/home/user/.sbt/boot/cc88a3ff57276e4d8968/)
 _            _  _               _      _                 _                 _ 
| |__    ___ | || |  ___    ___ | |__  | |_    ___ __  __| |_  _ __   __ _ | |
| '_ \  / _ \| || | / _ \  / __|| '_ \ | __|  / _ \\ \/ /| __|| '__| / _` || |
| | | ||  __/| || || (_) | \__ \| |_) || |_  |  __/ >  < | |_ | |   | (_| ||_|
|_| |_| \___||_||_| \___/  |___/|_.__/  \__|  \___|/_/\_\ \__||_|    \__,_|(_)
```
thus demonstrating that `residual_args` are also properly passed to the script.

I'm not sure if this PR would be affected by the bug described in #122.
Any feedback would be very much appreciated.