### PR TITLE
Use absolute package for fully qualified names

### DIFF
--- a/sbt
+++ b/sbt
@@ -182,7 +182,7 @@ setScalaVersion () {
 }
 setJavaHome () {
   java_cmd="$1/bin/java"
-  setThisBuild javaHome "scala.Some(file(\"$1\"))"
+  setThisBuild javaHome "_root_.scala.Some(file(\"$1\"))"
   export JAVA_HOME="$1"
   export JDK_HOME="$1"
   export PATH="$JAVA_HOME/bin:$PATH"
@@ -393,7 +393,7 @@ process_args () {
   -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
     -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
    -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
-       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "scala.Some(file(\"$2\"))" && shift 2 ;;
+       -scala-home) require_arg path "$1" "$2" && setThisBuild scalaHome "_root_.scala.Some(file(\"$2\"))" && shift 2 ;;
         -java-home) require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
          -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
          -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;

--- a/test/scala.bats
+++ b/test/scala.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-@test "-scala-home => scalaHome"              { sbt_expecting 'set scalaHome in ThisBuild := scala.Some(file("scala"))' -scala-home scala;                }
+@test "-scala-home => scalaHome"              { sbt_expecting 'set scalaHome in ThisBuild := _root_.scala.Some(file("scala"))' -scala-home scala;                }
 @test "-binary-version => scalaBinaryVersion" { sbt_expecting 'set scalaBinaryVersion in ThisBuild := "2.10.2"' -binary-version 2.10.2;             }
 @test "-scala-version SNAPSHOT => resolver"   { sbt_expecting 'set resolvers += Resolver.sonatypeRepo("snapshots")' -scala-version 2.12.0-SNAPSHOT; }
 @test "-28 => scala 2.8"                      { sbt_expecting "++ 2.8.2" -28;                                                                       }


### PR DESCRIPTION
Addresses a problem introduced by 1e6c083 when overriding `scalaHome` or `javaHome` in conjunction with using a plugin that contains a member named `scala`.