### PR TITLE
tiered compilation core dumps recent OpenJDK

### DIFF
--- a/sbt
+++ b/sbt
@@ -121,7 +121,7 @@ init_default_option_file () {
 }
 
 declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
-declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
+declare -r jit_opts="-XX:ReservedCodeCacheSize=256m"
 declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"


### PR DESCRIPTION
It's an upstream bug that has been fixed already, but hasn't been
released yet, tracked under Azul report 7781 (I can't find an online
ticket for it and probably finding the fixed commit means investigating
mercurial)