### PR TITLE
Drop setJavaHomeQuietly via JAVA_HOME/JDK_HOME

### DIFF
--- a/sbt
+++ b/sbt
@@ -193,18 +193,6 @@ setJavaHome () {
   export JDK_HOME="$1"
   export PATH="$JAVA_HOME/bin:$PATH"
 }
-setJavaHomeQuietly () {
-  addSbt warn
-  setJavaHome "$1"
-  addSbt info
-}
-
-# if set, use JDK_HOME/JAVA_HOME over java found in path
-if [[ -n "$JDK_HOME" && -e "$JDK_HOME/lib/tools.jar" ]]; then
-  setJavaHomeQuietly "$JDK_HOME"
-elif [[ -n "$JAVA_HOME" && -e "$JAVA_HOME/bin/java" ]]; then
-  setJavaHomeQuietly "$JAVA_HOME"
-fi
 
 # directory to store sbt launchers
 [[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
@@ -373,9 +361,9 @@ process_args () {
     case "$1" in
           -h|-help) usage; exit 1 ;;
                 -v) verbose=true && shift ;;
-                -d) addSbt "--debug" && addSbt debug && shift ;;
-                -w) addSbt "--warn"  && addSbt warn  && shift ;;
-                -q) addSbt "--error" && addSbt error && shift ;;
+                -d) addSbt "--debug" && shift ;;
+                -w) addSbt "--warn"  && shift ;;
+                -q) addSbt "--error" && shift ;;
                 -x) debugUs=true && shift ;;
             -trace) require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
               -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
@@ -413,9 +401,6 @@ process_args () {
               -211) setScalaVersion "$latest_211" && shift ;;
               -212) setScalaVersion "$latest_212" && shift ;;
 
-           --debug) addSbt debug && addResidual "$1" && shift ;;
-            --warn) addSbt warn  && addResidual "$1" && shift ;;
-           --error) addSbt error && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac
   done


### PR DESCRIPTION
This effectively:
  * reverts most of #95: setting javaHome via JAVA_HOME
  * reverts most of #96: setting javaHome via JDK_HOME
  * fixes #99: unbreaking sbt-extras possibly up to sbt version 0.11.2
  * fixes #122: unbreaks sbt.ScriptMain

See #122 for an example script that now works.

Also, as detailed in #122, the recommended method for dealing with java version and java home things is using 'jenv' from http://www.jenv.be/.

Review by @paulp and @fommil.