### PR TITLE
Fix `wget: unrecognized option: quiet`

### DIFF
--- a/sbt
+++ b/sbt
@@ -273,7 +273,7 @@ download_url () {
     if which curl >/dev/null; then
       curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
-      wget --quiet -O "$jar" "$url"
+      wget -q -O "$jar" "$url"
     fi
   } && [[ -r "$jar" ]]
 }


### PR DESCRIPTION
Fix for alpine linux with BusyBox v1.24.2:
`wget: unrecognized option: quiet`