### PR TITLE
Don't overwrite sbt_explicit_version

### DIFF
--- a/sbt
+++ b/sbt
@@ -399,7 +399,7 @@ process_args () {
               -210) setScalaVersion "$latest_210" && shift ;;
               -211) setScalaVersion "$latest_211" && shift ;;
               -212) setScalaVersion "$latest_212" && shift ;;
-               new) sbt_new=true && sbt_explicit_version="$sbt_release_version"  && addResidual "$1" && shift ;;
+               new) sbt_new=true && : ${sbt_explicit_version:=$sbt_release_version} && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac
   done


### PR DESCRIPTION
Discovered when executing

    sbt -sbt-version 0.13.16-SNAPSHOT new scala/scala-seed.g8

It would use sbt 0.13.15, because that's the current
sbt_release_version.