### PR TITLE
Switch to https://git.io/sbt in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ required versions of sbt and scala, downloading them if necessary.
 Put the (self-contained) [sbt script](https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt "sbt") somewhere on your path, for instance:
 
 ```bash
-curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > ~/bin/sbt \
-  && chmod 0755 ~/bin/sbt
+curl -Ls https://git.io/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
 ```
 
 ## Sample usage


### PR DESCRIPTION
This is a lot shorter and more memorable than the original
raw.githubusercontent.com version.

This is a retake on my attempt in #78 (in 2014!), with the following
benefits:

* Uses GitHub-owned git.io URL shortener rather than the third-party
  tinyurl.com
* It's shortened with "sbt" rather than "paulp-sbt" this time round

Unfortunately I couldn't shorten
https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt or
http://github.com/paulp/sbt-extras/raw/master/sbt directly because they
already had associated generated codes, so couldn't be associated to the
"sbt" code. So I'm using
https://raw.github.com/paulp/sbt-extras/master/sbt.

Are you on a machine and want sbt? You just have to curl git.io/sbt.
Both https and http work.

Reference:

    $ curl -IL https://git.io/sbt
    HTTP/1.1 302 Found
    Server: Cowboy
    Connection: keep-alive
    Date: Tue, 02 May 2017 09:09:32 GMT
    Status: 302 Found
    Content-Type: text/html;charset=utf-8
    Location: https://raw.github.com/paulp/sbt-extras/master/sbt
    Content-Length: 0
    X-Xss-Protection: 1; mode=block
    X-Content-Type-Options: nosniff
    X-Frame-Options: SAMEORIGIN
    X-Runtime: 0.006299
    X-Node: af285be0-605f-4987-bc2b-409c162b05ca
    X-Revision: 392798d237fc1aa5cd55cada10d2945773e741a8
    Strict-Transport-Security: max-age=31536000; includeSubDomains
    Via: 1.1 vegur

    HTTP/1.1 301 Moved Permanently
    Location: https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt
    Content-Length: 0
    Accept-Ranges: bytes
    Date: Tue, 02 May 2017 09:09:33 GMT
    Via: 1.1 varnish
    Age: 0
    Connection: keep-alive
    X-Served-By: cache-lcy1121-LCY
    X-Cache: MISS
    X-Cache-Hits: 0
    Vary: Accept-Encoding
    X-Fastly-Request-ID: 847dae1e76e97191fbb8f0904adb736ce9b42365

    HTTP/1.1 200 OK
    Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'
    Strict-Transport-Security: max-age=31536000
    X-Content-Type-Options: nosniff
    X-Frame-Options: deny
    X-XSS-Protection: 1; mode=block
    ETag: "f0b5bddd8b44ca4fd5fc2aafab9fb5286a6928a3"
    Content-Type: text/plain; charset=utf-8
    Cache-Control: max-age=300
    X-Geo-Block-List:
    X-GitHub-Request-Id: 1292:5544:15F4272:16D5209:59084C97
    Content-Length: 21298
    Accept-Ranges: bytes
    Date: Tue, 02 May 2017 09:09:33 GMT
    Via: 1.1 varnish
    Connection: keep-alive
    X-Served-By: cache-lcy1150-LCY
    X-Cache: HIT
    X-Cache-Hits: 2
    X-Timer: S1493716173.307059,VS0,VE0
    Vary: Authorization,Accept-Encoding
    Access-Control-Allow-Origin: *
    X-Fastly-Request-ID: bddf4a72ddde9a1708384285c3e37723d46c9333
    Expires: Tue, 02 May 2017 09:14:33 GMT
    Source-Age: 54