### PR TITLE
Fix Cygwin support (alternative implementation)

### DIFF
--- a/sbt
+++ b/sbt
@@ -245,9 +245,12 @@ jar_url ()  { make_url "$1"; }
 is_cygwin () [[ "$(uname -a)" == "CYGWIN"* ]]
 
 jar_file () {
+  echo "$sbt_launch_dir/$1/sbt-launch.jar"
+}
+jar_file_jvm () {
   is_cygwin \
-  && echo "$(cygpath -w $sbt_launch_dir/"$1"/sbt-launch.jar)" \
-  || echo "$sbt_launch_dir/$1/sbt-launch.jar"
+  && echo "$(cygpath -w "$sbt_jar")" \
+  || echo "$sbt_jar"
 }
 
 download_url () {
@@ -537,7 +540,7 @@ main () {
   execRunner "$java_cmd" \
     "${extra_jvm_opts[@]}" \
     "${java_args[@]}" \
-    -jar "$sbt_jar" \
+    -jar "$(jar_file_jvm)" \
     "${sbt_commands[@]}" \
     "${residual_args[@]}"
 }


### PR DESCRIPTION
Every external tool used by the script accepts only Cygwin paths, with the exception of the JVM, which accepts only Windows paths.

The current state of the script evaluates `mkdir -p "${jar%/*}"` as the full Windows path, turning the sbt launcher jar into a directory. This causes the script to promptly exit with the error `Download failed. Obtain the jar manually and place it at ...`.

This pull request proposes an additional function, `jar_file_jvm`, which converts `$sbt_jar` to the appropriate representation for use when invoking the JVM. The `jar_file` function will no longer perform this conversion.

This addresses #198