### PR TITLE
Switch from which to command to determine whether curl or wget is installed.

### DIFF
--- a/sbt
+++ b/sbt
@@ -260,9 +260,9 @@ download_url () {
   echoerr "    To  $jar"
 
   mkdir -p "${jar%/*}" && {
-    if which curl >/dev/null; then
+    if command -v curl > /dev/null 2>&1; then
       curl --fail --silent --location "$url" --output "$jar"
-    elif which wget >/dev/null; then
+    elif command -v wget > /dev/null 2>&1; then
       wget -q -O "$jar" "$url"
     fi
   } && [[ -r "$jar" ]]


### PR DESCRIPTION
The use of `command` in place of `which` is more portable. In our case, we run our builds in Docker containers and the centos7 image no longer ships with `which`.  There's a very detailed analysis of `which` and its alternatives here:

https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then

tl/dr; To find out if a given command exists:
```
if command -v given-command > /dev/null 2>&1; then
  echo given-command is available
else
  echo given-command is not available
fi
```