### PR TITLE
Scala 2.12.6, 2.13.0-M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ runner with the -x option.
   -210                      use 2.10.7
   -211                      use 2.11.12
   -212                      use 2.12.6
-  -213                      use 2.13.0-M2
+  -213                      use 2.13.0-M3
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ runner with the -x option.
   -29                       use 2.9.3
   -210                      use 2.10.7
   -211                      use 2.11.12
-  -212                      use 2.12.4
+  -212                      use 2.12.6
   -213                      use 2.13.0-M2
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala

--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ declare -r sbt_release_version="0.13.16"
 declare -r sbt_unreleased_version="0.13.16"
 
 declare -r latest_213="2.13.0-M2"
-declare -r latest_212="2.12.4"
+declare -r latest_212="2.12.6"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"

--- a/sbt
+++ b/sbt
@@ -9,7 +9,7 @@ set -o pipefail
 declare -r sbt_release_version="0.13.16"
 declare -r sbt_unreleased_version="0.13.16"
 
-declare -r latest_213="2.13.0-M2"
+declare -r latest_213="2.13.0-M3"
 declare -r latest_212="2.12.6"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"

--- a/test/scala.bats
+++ b/test/scala.bats
@@ -10,5 +10,5 @@ load test_helper
 @test "-210 => scala 2.10"                    { sbt_expecting "++ 2.10.7" -210;                                                                     }
 @test "-211 => scala 2.11"                    { sbt_expecting "++ 2.11.12" -211;                                                                    }
 @test "-212 => scala 2.12"                    { sbt_expecting "++ 2.12.6" -212;                                                                     }
-@test "-213 => scala 2.13"                    { sbt_expecting "++ 2.13.0-M2" -213;                                                                     }
+@test "-213 => scala 2.13"                    { sbt_expecting "++ 2.13.0-M3" -213;                                                                     }
 @test "-scala-version N => version N"         { sbt_expecting "++ 2.10.2" -scala-version 2.10.2;                                                    }

--- a/test/scala.bats
+++ b/test/scala.bats
@@ -9,6 +9,6 @@ load test_helper
 @test "-29 => scala 2.9"                      { sbt_expecting "++ 2.9.3" -29;                                                                       }
 @test "-210 => scala 2.10"                    { sbt_expecting "++ 2.10.7" -210;                                                                     }
 @test "-211 => scala 2.11"                    { sbt_expecting "++ 2.11.12" -211;                                                                    }
-@test "-212 => scala 2.12"                    { sbt_expecting "++ 2.12.4" -212;                                                                     }
+@test "-212 => scala 2.12"                    { sbt_expecting "++ 2.12.6" -212;                                                                     }
 @test "-213 => scala 2.13"                    { sbt_expecting "++ 2.13.0-M2" -213;                                                                     }
 @test "-scala-version N => version N"         { sbt_expecting "++ 2.10.2" -scala-version 2.10.2;                                                    }


### PR DESCRIPTION
Apr 27

https://github.com/scala/scala/releases/tag/v2.12.6

Jan 31

https://github.com/scala/scala/releases/tag/v2.13.0-M3