### PR TITLE
Switch sbt_explicit_version to use -Dsbt.version

### DIFF
--- a/sbt
+++ b/sbt
@@ -98,21 +98,6 @@ build_props_sbt () {
     grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
 }
 
-update_build_props_sbt () {
-  local ver="$1"
-  local old="$(build_props_sbt)"
-
-  [[ -r "$buildProps" ]] && [[ "$ver" != "$old" ]] && {
-    perl -pi -e "s/^sbt\.version\b.*\$/sbt.version=${ver}/" "$buildProps"
-    grep -q '^sbt.version[ =]' "$buildProps" || printf "\nsbt.version=%s\n" "$ver" >> "$buildProps"
-
-    vlog "!!!"
-    vlog "!!! Updated file $buildProps setting sbt.version to: $ver"
-    vlog "!!! Previous value was: $old"
-    vlog "!!!"
-  }
-}
-
 set_sbt_version () {
   sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
   [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
@@ -474,8 +459,7 @@ setTraceLevel() {
 # set scalacOptions if we were given any -S opts
 [[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
 
-# Update build.properties on disk to set explicit version - sbt gives us no choice
-[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && update_build_props_sbt "$sbt_explicit_version"
+[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && addJava "-Dsbt.version=$sbt_explicit_version"
 vlog "Detected sbt version $sbt_version"
 
 if [[ -n "$sbt_script" ]]; then


### PR DESCRIPTION
.. rather than modifying build.properties.

From archeology it looks like back in Feb 2012, when sbt 0.11.2 [1] was
the latest and greatest and 0.12.0-M1 [2] was out, the sbt.version in
build.properties was the only way to specify to sbt's launcher the
version of sbt to launch [3].

[1]: https://github.com/sbt/sbt/releases/tag/v0.11.2
[2]: https://github.com/sbt/sbt/releases/tag/v0.12.0-M1
[3]: https://github.com/paulp/sbt-extras/commit/7bfd06dc51b815087267f8ee3a9a35b94c1b0cf8

However a few months later, in May 2012, Mark added support [4] for the
sbt.version system property, support which shipped in the following sbt
0.11.x releases and 0.12.x pre-releases.

[4]: https://github.com/sbt/sbt/commit/f39af0bab3e3d4ab3e756864c6adecfd21a5f9c9

Therefore, this patch makes sbt_explicit_version not work on
sbt < 0.12.0 and < 0.11.3.

The motivation is, in general, that this type of command-line option
("-sbt-version") shouldn't need to modify files. In particular this
interferes with sbt-dynver, seeing as it uses git metadata (including
the dirty state of the worktree) to determine the value of the "version"
key.