### PR TITLE
Remove maximum Java heap size (MaxHeapSize)

### DIFF
--- a/sbt
+++ b/sbt
@@ -23,7 +23,7 @@ declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy
 declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
 declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
-declare -r default_jvm_opts_common="-Xms512m -Xmx1536m -Xss2m"
+declare -r default_jvm_opts_common="-Xms512m -Xss2m"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 
 declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new

--- a/test/basic.bats
+++ b/test/basic.bats
@@ -9,7 +9,6 @@ load test_helper
   assert_output <<EOS
 java
 -Xms512m
--Xmx1536m
 -Xss2m
 -jar
 \$ROOT/.sbt/launchers/$sbt_release/sbt-launch.jar


### PR DESCRIPTION
I suggest removing this configuration in order to give sbt more memory.

The JVM should give 1/4th of the physical memory. This can be verified by running:
  java -XX:+PrintFlagsFinal -version | grep MaxHeapSize

Since computers of at least 6 GB of physical memory became more common, I suggest removing this constraint.
