### PR TITLE
scala 2.13.0-M5

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ runner with the -x option.
   -210                      use 2.10.7
   -211                      use 2.11.12
   -212                      use 2.12.6
-  -213                      use 2.13.0-M4
+  -213                      use 2.13.0-M5
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies

--- a/sbt
+++ b/sbt
@@ -9,7 +9,7 @@ set -o pipefail
 declare -r sbt_release_version="0.13.17"
 declare -r sbt_unreleased_version="0.13.17"
 
-declare -r latest_213="2.13.0-M4"
+declare -r latest_213="2.13.0-M5"
 declare -r latest_212="2.12.6"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"

--- a/test/scala.bats
+++ b/test/scala.bats
@@ -10,5 +10,5 @@ load test_helper
 @test "-210 => scala 2.10"                    { sbt_expecting "++ 2.10.7" -210;                                                                     }
 @test "-211 => scala 2.11"                    { sbt_expecting "++ 2.11.12" -211;                                                                    }
 @test "-212 => scala 2.12"                    { sbt_expecting "++ 2.12.6" -212;                                                                     }
-@test "-213 => scala 2.13"                    { sbt_expecting "++ 2.13.0-M4" -213;                                                                     }
+@test "-213 => scala 2.13"                    { sbt_expecting "++ 2.13.0-M5" -213;                                                                     }
 @test "-scala-version N => version N"         { sbt_expecting "++ 2.10.2" -scala-version 2.10.2;                                                    }


### PR DESCRIPTION
Per https://github.com/scala/scala/releases/tag/v2.13.0-M5

~~This would be the change but I haven't had success pulling from Maven yet.~~

Edit: Seems okay now.