### PR TITLE
update sbt to 0.13.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sbt -v[erbosely] creating a new project built with the latest scala 2.10.x.
 [addSbt] arg = '++ 2.10.7'
 [residual] arg = 'about'
 No extra sbt options have been defined
-Detected sbt version 0.13.17
+Detected sbt version 0.13.18
 Using default jvm options
 Detected Java version: 1.8.0_121
 # Executing command line:
@@ -44,12 +44,12 @@ java
 -Xmx1536m
 -Xss2m
 -jar
-$HOME/.sbt/launchers/0.13.17/sbt-launch.jar
+$HOME/.sbt/launchers/0.13.18/sbt-launch.jar
 "++ 2.10.7"
 about
 
 [info] Setting version to 2.10.7
-[info] This is sbt 0.13.17
+[info] This is sbt 0.13.18
 [info] The current project is built against Scala 2.10.7
 [info] sbt, sbt plugins, and build definitions are using Scala 2.10.7
 ```
@@ -87,10 +87,10 @@ runner with the -x option.
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
   -script <file>     Run the specified file as a scala script
 
-  # sbt version (default: sbt.version from project/build.properties if present, otherwise 0.13.17)
-  -sbt-force-latest         force the use of the latest release of sbt: 0.13.17
-  -sbt-version  <version>   use the specified version of sbt (default: 0.13.17)
-  -sbt-dev                  use the latest pre-release version of sbt: 0.13.17
+  # sbt version (default: sbt.version from project/build.properties if present, otherwise 0.13.18)
+  -sbt-force-latest         force the use of the latest release of sbt: 0.13.18
+  -sbt-version  <version>   use the specified version of sbt (default: 0.13.18)
+  -sbt-dev                  use the latest pre-release version of sbt: 0.13.18
   -sbt-jar      <path>      use the specified jar as the sbt launcher
   -sbt-launch-dir <path>    directory to hold sbt launchers (default: ~/.sbt/launchers)
   -sbt-launch-repo <url>    repo url for downloading sbt launcher jar (default: http://repo.typesafe.com/typesafe/ivy-releases)

--- a/sbt
+++ b/sbt
@@ -6,8 +6,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="0.13.17"
-declare -r sbt_unreleased_version="0.13.17"
+declare -r sbt_release_version="0.13.18"
+declare -r sbt_unreleased_version="0.13.18"
 
 declare -r latest_213="2.13.0-M5"
 declare -r latest_212="2.12.7"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -11,9 +11,9 @@ export sbt_07="0.7.7"
 export sbt_10="0.10.1"
 export sbt_11="0.11.3"
 export sbt_12="0.12.4"
-export sbt_13="0.13.17"
+export sbt_13="0.13.18"
 export sbt_release="$sbt_13"
-export sbt_dev="0.13.17"
+export sbt_dev="0.13.18"
 
 write_version_to_properties () { write_to_properties "sbt.version=$1";  }
 write_to_properties ()         { printf "$@" > "$test_build_properties"; }


### PR DESCRIPTION
No rush on merging. Not even sure what's in `0.13.18`! But this is what the change would be.

https://github.com/sbt/sbt/releases/tag/v0.13.18

Edit: Release notes were blank at the time but they have since been updated.