### PR TITLE
Harden

### DIFF
--- a/sbt
+++ b/sbt
@@ -292,8 +292,17 @@ verify_sbt_jar() {
   local jar="${1}"
   local md5="${jar}.md5"
 
+  if command -v md5sum > /dev/null 2>&1; then
+    md5_cmd="md5sum"
+  elif command -v md5 > /dev/null 2>&1; then
+    md5_cmd="md5"
+  else
+    echoerr "Could not find an MD5 command"
+    return 1
+  fi
+
   download_url "$(make_url "${sbt_version}").md5" "${md5}" > /dev/null 2>&1
-  if echo "$(cat "${md5}")  ${jar}" | md5sum -c -; then
+  if echo "$(cat "${md5}")  ${jar}" | "${md5_cmd}" -c -; then
     rm -f "${md5}"
     return 0
   else

--- a/sbt
+++ b/sbt
@@ -18,10 +18,10 @@ declare -r latest_28="2.8.2"
 
 declare -r buildProps="project/build.properties"
 
-declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
-declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
 declare -r default_jvm_opts_common="-Xms512m -Xss2m"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
@@ -111,7 +111,7 @@ url_base () {
   local version="$1"
 
   case "$version" in
-        0.7.*) echo "http://simple-build-tool.googlecode.com" ;;
+        0.7.*) echo "https://simple-build-tool.googlecode.com" ;;
       0.10.* ) echo "$sbt_launch_ivy_release_repo" ;;
     0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
     0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"

--- a/sbt
+++ b/sbt
@@ -292,21 +292,34 @@ verify_sbt_jar() {
   local jar="${1}"
   local md5="${jar}.md5"
 
+  download_url "$(make_url "${sbt_version}").md5" "${md5}" > /dev/null 2>&1
+
   if command -v md5sum > /dev/null 2>&1; then
-    md5_cmd="md5sum"
+    if echo "$(cat "${md5}")  ${jar}" | md5sum -c -; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
   elif command -v md5 > /dev/null 2>&1; then
-    md5_cmd="md5"
+    if [ "$(md5 -q "${jar}")" == "$(cat "${md5}")" ]; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
+  elif command -v openssl > /dev/null 2>&1; then
+    if [ "$(openssl md5 -r "${jar}" | awk '{print $1}')" == "$(cat "${md5}")" ]; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
   else
     echoerr "Could not find an MD5 command"
-    return 1
-  fi
-
-  download_url "$(make_url "${sbt_version}").md5" "${md5}" > /dev/null 2>&1
-  if echo "$(cat "${md5}")  ${jar}" | "${md5_cmd}" -c -; then
-    rm -f "${md5}"
-    return 0
-  else
-    echoerr "Checksum does not match"
     return 1
   fi
 }

--- a/sbt
+++ b/sbt
@@ -255,12 +255,6 @@ download_url () {
   local url="$1"
   local jar="$2"
 
-  if [ -z "$3" ]; then
-    echoerr "Downloading sbt launcher for $sbt_version:"
-    echoerr "  From  $url"
-    echoerr "    To  $jar"
-  fi
-
   mkdir -p "${jar%/*}" && {
     if command -v curl > /dev/null 2>&1; then
       curl --fail --silent --location "$url" --output "$jar"
@@ -279,7 +273,13 @@ acquire_sbt_jar () {
     [[ -r "$sbt_jar" ]]
   } || {
     sbt_jar="$(jar_file "$sbt_version")"
-    download_url "$(make_url "$sbt_version")" "$sbt_jar"
+    jar_url="$(make_url "$sbt_version")"
+
+    echoerr "Downloading sbt launcher for ${sbt_version}:"
+    echoerr "  From  ${jar_url}"
+    echoerr "    To  ${sbt_jar}"
+
+    download_url "${jar_url}" "${sbt_jar}"
 
     case "${sbt_version}" in
       0.*) vlog "SBT versions < 1.0 do not have published MD5 checksums, skipping check"; echo "" ;;
@@ -292,7 +292,7 @@ verify_sbt_jar() {
   local jar="${1}"
   local md5="${jar}.md5"
 
-  download_url "$(make_url "${sbt_version}").md5" "${md5}" true > /dev/null 2>&1
+  download_url "$(make_url "${sbt_version}").md5" "${md5}" > /dev/null 2>&1
   if echo "$(cat "${md5}")  ${jar}" | md5sum -c -; then
     rm -f "${md5}"
     return 0
@@ -518,7 +518,7 @@ EOM
 # no jar? download it.
 [[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
   # still no jar? uh-oh.
-  echo "Download failed. Obtain the jar manually and place it at $sbt_jar"
+  echo "Could not download and verify the launcher. Obtain the jar manually and place it at $sbt_jar"
   exit 1
 }
 

--- a/test/download.bats
+++ b/test/download.bats
@@ -17,13 +17,21 @@ wget_opts='--quiet -O * https://* : mkdir -p "$(dirname "$3")" && touch "$3"'
 
 stub_curl() { stub curl "$curl_opts"; }
 stub_wget() { stub wget "$wget_opts"; }
+stub_md5sum() { stub md5sum 'true'; }
 
 launcher_url () {
   case "$1" in
     0.7.*) echo "https://simple-build-tool.googlecode.com/files/sbt-launch-$1.jar" ;;
    0.10.*) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
-      1.*) echo "https://repo.scala-sbt.org/scalasbt/maven-releases/org/scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+      1.*) echo "https://repo.scala-sbt.org/scalasbt/maven-releases/org/scala-sbt/sbt-launch/$1/sbt-launch-$1.jar" ;;
         *) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+  esac
+}
+
+checksum_output() {
+  case "$1" in
+    0.*) echo "SBT versions < 1.0 do not have published MD5 checksums, skipping check" ;;
+    *) echo "OK" ;;
   esac
 }
 
@@ -34,6 +42,8 @@ no_properties_and_fetch ()               { assert_no_properties && fetch_launche
 fetch_launcher () {
   local version="$1" && shift
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt "$@"
   assert_success
   assert_output <<EOS
@@ -41,7 +51,6 @@ Downloading sbt launcher for $version:
   From  $(launcher_url $version)
     To  $TEST_ROOT/.sbt/launchers/$version/sbt-launch.jar
 EOS
-  unstub curl
 }
 
 @test "downloads sbt 0.7.x"  { write_version_to_properties_and_fetch "$sbt_07"; }
@@ -59,6 +68,8 @@ EOS
 @test "downloads specified version when -sbt-version was given, even if there is build.properties" {
   write_version_to_properties $sbt_12
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt -sbt-version $sbt_13
   assert_success
   assert_output <<EOS
@@ -66,12 +77,13 @@ Downloading sbt launcher for $sbt_13:
   From  https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_13/sbt-launch.jar
 EOS
-  unstub curl
 }
 
 @test "downloads released version when -sbt-force-latest was given, even if there is build.properties" {
   write_version_to_properties $sbt_12
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt -sbt-force-latest
   assert_success
   assert_output <<EOS
@@ -79,12 +91,13 @@ Downloading sbt launcher for $sbt_release:
   From  $(launcher_url $sbt_release)
     To  $TEST_ROOT/.sbt/launchers/$sbt_release/sbt-launch.jar
 EOS
-  unstub curl
 }
 
 @test "downloads unreleased version when -sbt-dev was given, even if there is build.properties" {
   write_version_to_properties $sbt_13
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt -sbt-dev
   assert_success
   assert_output <<EOS
@@ -92,7 +105,6 @@ Downloading sbt launcher for $sbt_dev:
   From  $(launcher_url $sbt_dev)
     To  $TEST_ROOT/.sbt/launchers/$sbt_dev/sbt-launch.jar
 EOS
-  unstub curl
 }
 
 @test "allows surrounding white spaces around '=' in build.properties" {
@@ -122,6 +134,8 @@ EOS
 @test "uses special launcher directory if -sbt-launch-dir was given" {
   write_to_properties "stub.version=$sbt_1"
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt -sbt-launch-dir "${sbt_project}/xsbt"
   assert_success
   assert_output <<EOS
@@ -129,18 +143,18 @@ Downloading sbt launcher for $sbt_1:
   From  $(launcher_url $sbt_1)
     To  ${sbt_project}/xsbt/$sbt_1/sbt-launch.jar
 EOS
-  unstub curl
 }
 
 @test "uses special launcher repository if -sbt-launch-repo was given" {
   write_to_properties "stub.version=$sbt_1"
   stub_curl
+  stub_curl
+  stub_md5sum
   run sbt -sbt-launch-repo "https://127.0.0.1:8080/ivy-releases"
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_1:
-  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch.jar
+  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch-$sbt_1.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar
 EOS
-  unstub curl
 }

--- a/test/download.bats
+++ b/test/download.bats
@@ -12,18 +12,18 @@ teardown() {
   rm -fr "$TEST_ROOT"/* "$TEST_ROOT"/.sbt
 }
 
-curl_opts='--fail --silent --location http://* --output * : mkdir -p "$(dirname "$6")" && touch "$6"'
-wget_opts='--quiet -O * http://* : mkdir -p "$(dirname "$3")" && touch "$3"'
+curl_opts='--fail --silent --location https://* --output * : mkdir -p "$(dirname "$6")" && touch "$6"'
+wget_opts='--quiet -O * https://* : mkdir -p "$(dirname "$3")" && touch "$3"'
 
 stub_curl() { stub curl "$curl_opts"; }
 stub_wget() { stub wget "$wget_opts"; }
 
 launcher_url () {
   case "$1" in
-    0.7.*) echo "http://simple-build-tool.googlecode.com/files/sbt-launch-$1.jar" ;;
-   0.10.*) echo "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
-      1.*) echo "http://repo.scala-sbt.org/scalasbt/maven-releases/org/scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
-        *) echo "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+    0.7.*) echo "https://simple-build-tool.googlecode.com/files/sbt-launch-$1.jar" ;;
+   0.10.*) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
+      1.*) echo "https://repo.scala-sbt.org/scalasbt/maven-releases/org/scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+        *) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
   esac
 }
 
@@ -63,7 +63,7 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_13:
-  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
+  From  https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$sbt_13/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_13/sbt-launch.jar
 EOS
   unstub curl
@@ -135,11 +135,11 @@ EOS
 @test "uses special launcher repository if -sbt-launch-repo was given" {
   write_to_properties "stub.version=$sbt_1"
   stub_curl
-  run sbt -sbt-launch-repo "http://127.0.0.1:8080/ivy-releases"
+  run sbt -sbt-launch-repo "https://127.0.0.1:8080/ivy-releases"
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_1:
-  From  http://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch.jar
+  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar
 EOS
   unstub curl


### PR DESCRIPTION
- [X] Switch all URLs to use HTTPS
- [X] Verify SBT launcher using signature and MD5 hash
- [X] Add -skip-verify to skip artifact verification
- [X] Added -skip-verify to download tests, I was unable to stub out md5sum, this should probably be fixed in a follow-up

The three GPG keys listed are the only ones in the entirety of http://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/

I do not have a macOS machine handy, so I do not know if this works there, needs testing.

/cc @dwijnand @alexarchambault
