### PR TITLE
Displays log output when retrieving md5 files

### DIFF
--- a/sbt
+++ b/sbt
@@ -315,8 +315,13 @@ acquire_sbt_jar() {
 verify_sbt_jar() {
   local jar="${1}"
   local md5="${jar}.md5"
+  md5url="$(make_url "${sbt_version}").md5"
 
-  download_url "$(make_url "${sbt_version}").md5" "${md5}" >/dev/null 2>&1
+  echoerr "Downloading sbt launcher ${sbt_version} md5 hash:"
+  echoerr "  From  ${md5url}"
+  echoerr "    To  ${md5}"
+
+  download_url "${md5url}" "${md5}" >/dev/null 2>&1
 
   if command -v md5sum >/dev/null 2>&1; then
     if echo "$(cat "${md5}")  ${jar}" | md5sum -c -; then

--- a/test/download.bats
+++ b/test/download.bats
@@ -47,14 +47,39 @@ no_properties_and_fetch ()               { assert_no_properties && fetch_launche
 
 fetch_launcher () {
   local version="$1" && shift
-  stub_curl "${version}"
-  run sbt "$@"
-  assert_success
-  assert_output <<EOS
+
+  jar_output=$(cat <<EOS
 Downloading sbt launcher for $version:
   From  $(launcher_url $version)
     To  $TEST_ROOT/.sbt/launchers/$version/sbt-launch.jar
 EOS
+)
+  md5_output=$(cat <<EOS
+Downloading sbt launcher $version md5 hash:
+  From  $(launcher_url $version).md5
+    To  $TEST_ROOT/.sbt/launchers/$version/sbt-launch.jar.md5
+EOS
+)
+
+  local output_text
+  # the md5 hash gets added only for sbt 1.x
+  case "${version}" in
+    0.*)
+      output_text="${jar_output}"
+      ;;
+    *)
+      output_text=$(cat <<EOS
+${jar_output}
+${md5_output}
+EOS
+)
+    ;;
+  esac
+
+  stub_curl "${version}"
+  run sbt "$@"
+  assert_success
+  assert_output "${output_text}"
   unstub curl
 }
 
@@ -92,6 +117,9 @@ EOS
 Downloading sbt launcher for $sbt_release:
   From  $(launcher_url $sbt_release)
     To  $TEST_ROOT/.sbt/launchers/$sbt_release/sbt-launch.jar
+Downloading sbt launcher $sbt_release md5 hash:
+  From  $(launcher_url $sbt_release).md5
+    To  $TEST_ROOT/.sbt/launchers/$sbt_release/sbt-launch.jar.md5
 EOS
   unstub curl
 }
@@ -105,6 +133,9 @@ EOS
 Downloading sbt launcher for $sbt_dev:
   From  $(launcher_url $sbt_dev)
     To  $TEST_ROOT/.sbt/launchers/$sbt_dev/sbt-launch.jar
+Downloading sbt launcher $sbt_dev md5 hash:
+  From  $(launcher_url $sbt_dev).md5
+    To  $TEST_ROOT/.sbt/launchers/$sbt_dev/sbt-launch.jar.md5
 EOS
   unstub curl
 }
@@ -142,6 +173,9 @@ EOS
 Downloading sbt launcher for $sbt_1:
   From  $(launcher_url $sbt_1)
     To  ${sbt_project}/xsbt/$sbt_1/sbt-launch.jar
+Downloading sbt launcher $sbt_1 md5 hash:
+  From  $(launcher_url $sbt_1).md5
+    To  ${sbt_project}/xsbt/$sbt_1/sbt-launch.jar.md5
 EOS
   unstub curl
 }
@@ -155,6 +189,9 @@ EOS
 Downloading sbt launcher for $sbt_1:
   From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch-$sbt_1.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar
+Downloading sbt launcher $sbt_1 md5 hash:
+  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch-$sbt_1.jar.md5
+    To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar.md5
 EOS
   unstub curl
 }


### PR DESCRIPTION
It's displayed for the launcher jar so perhaps show it for the md5 file, too.

I encountered a problem today wherein I suspected that the MD5 file URL was getting munged by a corporate firewall, so I exposed the URL in this manner. It seems worthwhile to notify the user that a file is being downloaded and the URL from while it is being retrieved.