### PR TITLE
Add license to `sbt` for the redistributions

### DIFF
--- a/sbt
+++ b/sbt
@@ -3,6 +3,34 @@
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@improving.org>
 # https://github.com/paulp/sbt-extras
+#
+# Generated from http://www.opensource.org/licenses/bsd-license.php
+# Copyright (c) 2011, Paul Phillips. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#     * Neither the name of the author nor the names of its contributors
+# may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -o pipefail
 


### PR DESCRIPTION
- This program is distributed under the `LICENSE.txt` and it requires: 
     > - Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
     > - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution
- But some libraries (for exapmle, [Scalaz](https://github.com/scalaz/scalaz/blob/master/sbt)) may not follow these sentences.... 😇 
- As I'm not an expert of lows nor licenses, I think these libraries which are using `sbt` don't want to violate the license
    - They are just using `sbt` because it's very useful
- In my opinion, if the license would be also written into `sbt` file, then almost programmers will follow the license automatically
- So I copy and paste the license to `sbt` from `LICENSE.txt`
- It causes dual cost to maintain `LICENSE.txt` and the license of `sbt`, indeed
    - But the last change of `LICENSE.txt` is 7 years ago, so it's not serious, isn't it? 🤔 

Thank you to the reading.