### PR TITLE
Fixes #297: Support Apple Silicon (M1)

### DIFF
--- a/sbt
+++ b/sbt
@@ -247,11 +247,18 @@ java_version() {
   echo "$version"
 }
 
+is_apple_silicon() { [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; }
+
 # MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts() {
   local -r v="$(java_version)"
   if [[ $v -ge 10 ]]; then
-    echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    if is_apple_silicon; then
+      # As of Dec 2020, JVM for Apple Silicon (M1) doesn't support JVMCI
+      echo "$default_jvm_opts_common"
+    else
+      echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    fi
   elif [[ $v -ge 8 ]]; then
     echo "$default_jvm_opts_common"
   else


### PR DESCRIPTION
This PR will enable running sbt-extra script under Apple Silicon (M1).

Currently, JVMCI interface is not supported in JVMs built for Apple Silicon (M1, Darwin arm64). This fix is a workaround for the error reported in #297. 

A downside of this fix is that this will disable using JVMCI compiler option if the user is using a JVM built for x64, but running with Rosetta2, which is a x64 - arm64 compatibility layer of M1. But, it was a bit difficult to check whether the jvm supports JVMCI or not without running any Java program. If we can run some Java code, we can check the availability of JVMCI compiler by looking at `java.vm.version` system property, but this would be overkill for a light-weight script like sbt-extras. 



