### PR TITLE
Restore fetching the version-tagged launch jar

### DIFF
--- a/sbt
+++ b/sbt
@@ -167,7 +167,7 @@ make_url() {
     0.10.*)    echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
     0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
     0.*)       echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
-    *)         echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    *)         echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch-${version}.jar" ;;
   esac
 }
 

--- a/test/download.bats
+++ b/test/download.bats
@@ -29,7 +29,7 @@ launcher_url () {
   case "$1" in
     0.7.*) echo "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/simple-build-tool/sbt-launch-$1.jar" ;;
    0.10.*) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/$1/sbt-launch.jar" ;;
-      1.*) echo "https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
+      1.*) echo "https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/$1/sbt-launch-$1.jar" ;;
         *) echo "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$1/sbt-launch.jar" ;;
   esac
 }
@@ -187,10 +187,10 @@ EOS
   assert_success
   assert_output <<EOS
 Downloading sbt launcher for $sbt_1:
-  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch.jar
+  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch-$sbt_1.jar
     To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar
 Downloading sbt launcher $sbt_1 md5 hash:
-  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch.jar.md5
+  From  https://127.0.0.1:8080/ivy-releases/org/scala-sbt/sbt-launch/$sbt_1/sbt-launch-$sbt_1.jar.md5
     To  $TEST_ROOT/.sbt/launchers/$sbt_1/sbt-launch.jar.md5
 EOS
   unstub curl


### PR DESCRIPTION
The un-version-tagged jar is the exception: version tagging is the norm
for maven publishing.  I think the unversioned jar was a historical
(mild) accident.  Changing back to it seems to me as an unintentional
part of the switch to Maven Central.

Fixes #309